### PR TITLE
1.14.2 compatibility along with some code cleanups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,18 +16,20 @@
     </repositories>
 
     <dependencies>
+
         <!--Spigot API-->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.11.2-R0.1-SNAPSHOT</version>
+            <version>1.14.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+
         <!--Bukkit API-->
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.11.2-R0.1-SNAPSHOT</version>
+            <version>1.14.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/me/konsolas/conditionalcommands/ConditionalCommands.java
+++ b/src/main/java/me/konsolas/conditionalcommands/ConditionalCommands.java
@@ -12,6 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ConditionalCommands extends JavaPlugin {
+
     private static final Pattern SPLIT_PATTERN = Pattern.compile("/([0-9]*)/");
 
     public void onEnable() {

--- a/src/main/java/me/konsolas/conditionalcommands/Expression.java
+++ b/src/main/java/me/konsolas/conditionalcommands/Expression.java
@@ -6,6 +6,7 @@ import java.io.StreamTokenizer;
 import java.io.StringReader;
 
 class Expression {
+
     private final BooleanExpression expression;
 
     Expression(String exp) {

--- a/src/main/java/me/konsolas/conditionalcommands/Placeholders.java
+++ b/src/main/java/me/konsolas/conditionalcommands/Placeholders.java
@@ -3,13 +3,21 @@ package me.konsolas.conditionalcommands;
 import me.konsolas.conditionalcommands.placeholders.*;
 
 enum Placeholders {
+
     PING(new PlaceholderPing()),
+
     TPS(new PlaceholderTPS()),
+
     TIME_ONLINE(new PlaceholderTimeOnline()),
+
     PLAYER_COUNT(new PlaceholderPlayerCount()),
+
     UPTIME(new PlaceholderUptime()),
+
     PERM(new PlaceholderPerm()),
+
     AACVL(new PlaceholderAACVL()),
+
     CHANCE(new PlaceholderChance());
 
     private Placeholder placeholder;

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/AbstractParameteredPlaceholder.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/AbstractParameteredPlaceholder.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public abstract class AbstractParameteredPlaceholder implements Placeholder {
+
     private final Pattern pattern;
 
     AbstractParameteredPlaceholder(String base) {

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/AbstractStandardPlaceholder.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/AbstractStandardPlaceholder.java
@@ -4,6 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 public abstract class AbstractStandardPlaceholder implements Placeholder {
+
     private String matcher;
 
     AbstractStandardPlaceholder(String matcher) {

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/Placeholder.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/Placeholder.java
@@ -4,6 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 public interface Placeholder {
+
     /**
      * Checks whether the given string contains a pattern that matches this placeholder
      *

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderAACVL.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderAACVL.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PlaceholderAACVL extends AbstractParameteredPlaceholder {
+
     private Map<String, Object> hackTypes = new HashMap<>();
     private Method getAPI;
     private Method getViolationLevel;

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderChance.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderChance.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class PlaceholderChance extends AbstractParameteredPlaceholder {
+
     public PlaceholderChance() {
         super("chance");
     }

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderPerm.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderPerm.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import java.util.regex.Pattern;
 
 public class PlaceholderPerm extends AbstractParameteredPlaceholder {
+
     private static final Pattern PERM_PATTERN = Pattern.compile("-perm:([A-Za-z0-9.]*)-");
 
     public PlaceholderPerm() {

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderPing.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderPing.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 public class PlaceholderPing extends AbstractStandardPlaceholder {
+
     private Method getHandleMethod;
     private Field pingField;
 

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderPlayerCount.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderPlayerCount.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 public class PlaceholderPlayerCount extends AbstractStandardPlaceholder {
+
     public PlaceholderPlayerCount() {
         super("player_count");
     }
@@ -12,4 +13,5 @@ public class PlaceholderPlayerCount extends AbstractStandardPlaceholder {
     public double getStat(Player player) {
         return Bukkit.getOnlinePlayers().size();
     }
+
 }

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderTPS.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderTPS.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.Deque;
 
 public class PlaceholderTPS extends AbstractStandardPlaceholder {
+
     private TPS tps;
 
     public PlaceholderTPS() {
@@ -26,8 +27,10 @@ public class PlaceholderTPS extends AbstractStandardPlaceholder {
     }
 
     private static class TPS extends BukkitRunnable {
+
         private int resolution = 40;
         private long lastTick;
+
         private Deque<Long> tickIntervals;
 
         private TPS(Plugin plugin) {

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderTimeOnline.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderTimeOnline.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PlaceholderTimeOnline extends AbstractStandardPlaceholder implements Listener {
+
     private final Map<Player, Long> loginTime = new HashMap<>();
 
     public PlaceholderTimeOnline() {
@@ -47,4 +48,5 @@ public class PlaceholderTimeOnline extends AbstractStandardPlaceholder implement
     public double getStat(Player player) {
         return System.currentTimeMillis() - loginTime.get(player);
     }
+
 }

--- a/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderUptime.java
+++ b/src/main/java/me/konsolas/conditionalcommands/placeholders/PlaceholderUptime.java
@@ -4,6 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 public class PlaceholderUptime extends AbstractStandardPlaceholder {
+
     private long startupTimeMS;
 
     public PlaceholderUptime() {
@@ -19,4 +20,5 @@ public class PlaceholderUptime extends AbstractStandardPlaceholder {
     public double getStat(Player player) {
         return (System.currentTimeMillis() - startupTimeMS) / 50;
     }
+
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: ConditionalCommands
 version: 1.4
 main: me.konsolas.conditionalcommands.ConditionalCommands
+api-version: 1.14
 description: Excecute commands based on conditions. Useful in configured commands from other plugins
 author: konsolas
 website: https://github.com/konsolas/ConditionalCommands


### PR DESCRIPTION
Simply change the used Bukkit and Spigot version in pom.xml to use 1.14.2 instead of 1.11.2. This should give more space for the plugin to function on future versions, beside setting `api-version` to `1.14` in any case this plugin was ever to use the new Material names.

(Also improved the whitespace in most of the classes)